### PR TITLE
vibrant visual 옵션 선택 가능하게 추가

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -24,6 +24,9 @@
             }
         }
     ],
+    "capabilities": [
+    "pbr"
+    ],
     "metadata": {
         "authors": [ "NeroLuna", "Team Selenyx" ],
         "license": "AGPL-3.0"


### PR DESCRIPTION
단순 번역팩인데도 불구하고
마크에서 vibrant visual 옵션을 미지원하는 리소스팩으로 인식하는 문제 수정